### PR TITLE
Add missing comma

### DIFF
--- a/Songs/Songs.Server/appsettings.json
+++ b/Songs/Songs.Server/appsettings.json
@@ -8,6 +8,6 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=DESKTOP-NPLNBMD\\SQLEXPRESS;Database=Songs;Integrated Security=True"
-  }
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Read the error message 😉😂: *Error: Could not parse the JSON file*. Just a missing comma.

Interestingly, one of your colleagues needed help a few days ago. He had a similiar problem. Learning: Don't ignore warning-squiggles in Visual Studio.

Hope that helps.

Greetings,
Rainer Stropek.